### PR TITLE
Возможность указания относительного пути для JSON-отчета

### DIFF
--- a/deepsecrets/cli.py
+++ b/deepsecrets/cli.py
@@ -201,6 +201,13 @@ class DeepSecretsCliTool:
             'Use this flag if you want to render found secrets in plaintext.',
         )
 
+        parser.add_argument(
+            '--relative-path',
+            action='store_true',
+            help='By default absolute path is used in JSON report.\n'
+            'Use this flag if you want to use relative path instead.',
+        )
+
         self.argparser = parser
 
     def parse_arguments(self) -> None:
@@ -211,6 +218,9 @@ class DeepSecretsCliTool:
 
         if user_args.disable_masking:
             config.set_disable_masking(True)
+
+        if user_args.relative_path:
+            config.set_relative_path(True)
 
         self.say_hello()
 
@@ -313,7 +323,7 @@ class DeepSecretsCliTool:
         with open(report_path, 'w+') as f:
 
             if config.output.type == 'json':
-                json.dump(FindingResponse.from_list(findings, config.disable_masking), f)
+                json.dump(FindingResponse.from_list(findings, config.disable_masking, config.relative_path), f)
 
             if config.output.type == 'dojo-sarif':
                 f.write(to_json(FindingResponse.dojo_sarif_from_list(findings, config.disable_masking)))

--- a/deepsecrets/config.py
+++ b/deepsecrets/config.py
@@ -32,6 +32,7 @@ class Config:
     process_count: int
     return_code_if_findings: bool
     disable_masking: bool
+    relative_path: bool
 
     def __init__(self) -> None:
         self.engines = []
@@ -39,6 +40,7 @@ class Config:
         self.global_exclusion_paths = []
         self.return_code_if_findings = False
         self.disable_masking = False
+        self.relative_path = False
 
         # equals to CPU count
         self.process_count = FALLBACK_PROCESS_COUNT
@@ -49,6 +51,9 @@ class Config:
 
     def set_disable_masking(self, state: bool):
         self.disable_masking = state
+    
+    def set_relative_path(self, state: bool):
+        self.relative_path = state
 
     def _set_path(self, path: str, field: str) -> None:
         if not path_exists(path):

--- a/deepsecrets/core/model/finding.py
+++ b/deepsecrets/core/model/finding.py
@@ -117,14 +117,18 @@ class FindingMerger:
 
 class FindingResponse:
     @classmethod
-    def from_list(cls, list: List[Finding], disable_masking: bool = False) -> Dict[str, List[Dict]]:
+    def from_list(cls, list: List[Finding], disable_masking: bool = False, relative_path: bool = False) -> Dict[str, List[Dict]]:
         resp: Dict[str, List[Dict]] = {}
         for finding in list:
             if finding.file is None:
                 continue
 
-            if finding.file.path not in resp:
-                resp[finding.file.path] = []
+            if not relative_path:
+                if finding.file.path not in resp:
+                    resp[finding.file.path] = []
+            else:
+                if finding.file.relative_path not in resp:
+                    resp[finding.file.relative_path] = []
 
             resp_finding = FindingApiModel.from_finding(finding)
 
@@ -133,7 +137,10 @@ class FindingResponse:
                 resp_finding.line = resp_finding.line.replace(resp_finding.string, '*' * len(resp_finding.string))
                 resp_finding.string = '*' * len(resp_finding.string)
 
-            resp[finding.file.path].append(resp_finding.model_dump())
+            if not relative_path:
+                resp[finding.file.path].append(resp_finding.model_dump())
+            else:
+                resp[finding.file.relative_path].append(resp_finding.model_dump())
 
         return resp
 


### PR DESCRIPTION
Привет!

Иногда хочется использовать относительный, а не абсолютный путь до файла. SARIF-вариант использует относительный, JSON - абсолютный.

Идея была в том, чтобы добавить возможность выбора пути (абсолютный или относительный) для JSON-варианта.

Прошу рассмотреть PR, готов его оперативно исправлять.

Спасибо!